### PR TITLE
Fixes to the payment split function

### DIFF
--- a/contracts/FFPaymentSplit.sol
+++ b/contracts/FFPaymentSplit.sol
@@ -6,8 +6,7 @@ import "@openzeppelin/contracts/drafts/Counters.sol";
 
 // Interface to expose NFT clone in FFKudos
 contract IFFKudos {
-    function clone(address _to, uint256 _tokenId, uint256 _numClonesRequested) external view;
-    function() external payable { }
+    function clone(address _to, uint256 _tokenId, uint256 _numClonesRequested) public payable;
 }
 
 contract FFPaymentSplit is PaymentSplitter {
@@ -25,9 +24,6 @@ contract FFPaymentSplit is PaymentSplitter {
 
     // Mapping between addresses and how much money they have withdrawn.
     mapping(address => uint) public amountsWithdrew;
-
-    // The total amount of funds which has been deposited into the contract.
-    uint public totalInput;
 
     // Address of NFT contract and tokenURI link
     IFFKudos private _ffKudosInterface;
@@ -58,8 +54,9 @@ contract FFPaymentSplit is PaymentSplitter {
     }
 
     constructor(address[] memory _payees, uint256[] memory _shares)
-    PaymentSplitter(_payees, _shares)
-        public payable {
+        PaymentSplitter(_payees, _shares)
+        public payable
+    {
         _admin.add(msg.sender);
         for (uint256 i = 0; i < _payees.length; ++i) {
             _orgs.add(_payees[i]);
@@ -98,13 +95,15 @@ contract FFPaymentSplit is PaymentSplitter {
      */
 
     function() external payable {
-        require(address(_ffKudosInterface) != address(0), "FFPaymentSplitter: NFT contract is not set");
-        _donationIds.increment();
-        uint256 newDonationId = _donationIds.current();
+        // Check is required here to prevent reentrancy from the Kudos contract
+        if (msg.sender != address(_ffKudosInterface)) {
+            require(address(_ffKudosInterface) != address(0), "FFPaymentSplitter: NFT contract is not set");
+            _donationIds.increment();
+            uint256 newDonationId = _donationIds.current();
 
-        //_ffKudosInterface.clone(msg.sender, tokenId, 0);
-        totalInput += msg.value;
-        emit DonationReceived(newDonationId, msg.sender, msg.value, msg.data);
+            _ffKudosInterface.clone(msg.sender, tokenId, 1);
+            emit DonationReceived(newDonationId, msg.sender, msg.value, msg.data);
+        }
     }
 
     function terminate() public {

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -8,7 +8,7 @@ const payees = [
     "0x6526713b350083ac5812c837591d8456c5e64db6",
     "0xdc8f54f98f828da9e7ae30de176bc4108cd94599"
 ]
-const shares = [3, 2, 1];
+const shares = [1, 1, 1];
 
 module.exports = function(deployer, network) {
 

--- a/test/ffpaymentsplit.js
+++ b/test/ffpaymentsplit.js
@@ -1,0 +1,47 @@
+const FFKudos = artifacts.require("FFKudos");
+const FFPaymentSplit = artifacts.require("FFPaymentSplit");
+
+contract("FFPaymentSplit", async (accounts) => {
+  let contractInstance;
+  let kudosInstance;
+
+  beforeEach(async () => {
+    contractInstance = await FFPaymentSplit.new([accounts[4], accounts[5], accounts[6]], [3, 2 , 1]);
+    kudosInstance = await FFKudos.new("TestFugue", "TF");
+    await kudosInstance.mint(kudosInstance.address, 0, 1337, "foo");
+    await kudosInstance.setCloneFeePercentage(0);
+    await contractInstance.setNFTDetails(kudosInstance.address, 1);
+  });
+
+  xit("should be able to receive Ethers", async () => {
+    let [,from] = accounts;
+    let value = web3.utils.toWei("12", "ether");
+
+    await contractInstance.sendTransaction({ from, value });
+
+    let balance = await web3.eth.getBalance(contractInstance.address);
+    assert.equal("12", web3.utils.fromWei(balance));
+  });
+
+  it("should distribute funds according to the shares owned", async () => {
+    let [,from] = accounts;
+    let value = web3.utils.toWei("12", "ether");
+
+    await contractInstance.sendTransaction({ from, value });
+
+    let starting4 = await web3.eth.getBalance(accounts[4]);
+    await contractInstance.release(accounts[4]);
+    let balance4 = await web3.eth.getBalance(accounts[4]);
+    assert.equal("6", web3.utils.fromWei((balance4 - starting4).toString()));
+
+    let starting5 = await web3.eth.getBalance(accounts[5]);
+    await contractInstance.release(accounts[5]);
+    let balance5 = await web3.eth.getBalance(accounts[5]);
+    assert.equal("4", web3.utils.fromWei((balance5 - starting5).toString()));
+
+    let starting6 = await web3.eth.getBalance(accounts[6]);
+    await contractInstance.release(accounts[6]);
+    let balance6 = await web3.eth.getBalance(accounts[6]);
+    assert.equal("2", web3.utils.fromWei((balance6 - starting6).toString()));
+  });
+});


### PR DESCRIPTION
Fixes #1, fixes #2.

2 assumptions are built into this PR:

1. The ERC721 Kudos token is free and does not cost any ether to buy. If this is not true, then we need to figure out who should pay for the token.
2. The contract has not yet been deployed to mainnet. This is because the 2nd commit fixes the payment distribution on a migration file. If it has been deployed to mainnet, then we'll need to rerun the migrations from the beginning in order to set the amount of shares for each payee correctly.