### PR TITLE
Enable addition and removal of organizations for payment split

### DIFF
--- a/contracts/FFPaymentSplit.sol
+++ b/contracts/FFPaymentSplit.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.0;
 
 import "@openzeppelin/contracts/access/Roles.sol";
-import "@openzeppelin/contracts/payment/PaymentSplitter.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/drafts/Counters.sol";
 
 // Interface to expose NFT clone in FFKudos
@@ -9,9 +9,15 @@ contract IFFKudos {
     function clone(address _to, uint256 _tokenId, uint256 _numClonesRequested) public payable;
 }
 
-contract FFPaymentSplit is PaymentSplitter {
+contract FFPaymentSplit {
+    using SafeMath for uint256;
+
+    uint constant MAX_EVALUATOR_ID = 5;
 
     event DonationReceived(uint donationId, address indexed donor, uint amount, bytes evaluator);
+    event OrgAdded(address org, uint evaluatorId);
+    event OrgRemoved(address org, uint evaluatorId);
+    event PaymentDistributed(address to, uint amount, uint evaluatorId);
 
     // OZ counter control
     using Counters for Counters.Counter;
@@ -23,6 +29,8 @@ contract FFPaymentSplit is PaymentSplitter {
 
     // Mapping between addresses and how much money they have withdrawn.
     mapping(address => uint) public amountsWithdrew;
+    mapping(uint => PaymentDetails) public paymentLedger;
+    mapping(address => uint) public evaluatorLookup;
 
     // Address of NFT contract and tokenURI link
     IFFKudos private _ffKudosInterface;
@@ -33,6 +41,12 @@ contract FFPaymentSplit is PaymentSplitter {
     Org[] private orgs;
     Donation[] private donations;
     uint private totalDonated;
+
+    struct PaymentDetails {
+        uint totalDistributed;
+        uint totalDonated;
+        address payable[] payees;
+    }
 
     struct Org {
         address addr;
@@ -47,11 +61,20 @@ contract FFPaymentSplit is PaymentSplitter {
         address from;
     }
 
-    constructor(address[] memory _payees, uint256[] memory _shares)
-        PaymentSplitter(_payees, _shares)
+    constructor(address payable[] memory _payees, uint[] memory _evaluatorIds)
         public payable
     {
+        require(_evaluatorIds.length == _payees.length, "Array size of _evaluatorIds does not match payees");
+
         _admin.add(msg.sender);
+
+        for (uint i = 0; i < _evaluatorIds.length; i++) {
+            uint evaluatorId = _evaluatorIds[i];
+            require(evaluatorId > 0 && evaluatorId <= MAX_EVALUATOR_ID, "Invalid evaluatorId supplied");
+
+            evaluatorLookup[_payees[i]] = evaluatorId;
+            paymentLedger[evaluatorId].payees.push(_payees[i]);
+        }
     }
 
     modifier onlyAdmin() {
@@ -73,18 +96,40 @@ contract FFPaymentSplit is PaymentSplitter {
 
     /**
      * @dev Allow admin role to add an organization.
+     * @param payee Address of the organization
+     * @param evaluatorId The evaluator ID for the payee organization
      */
 
-    // function addOrg() public onlyAdmin{
-    // }
+    function addOrg(address payable payee, uint evaluatorId) public onlyAdmin {
+        require(evaluatorId > 0 && evaluatorId <= MAX_EVALUATOR_ID, "Invalid evaluatorId supplied");
+        evaluatorLookup[payee] = evaluatorId;
+        paymentLedger[evaluatorId].payees.push(payee);
+        emit OrgAdded(payee, evaluatorId);
+    }
 
     /**
      * @dev Allow admin role to remove an organization.
-     * @param id Org id
+     * @param payee The address of the organization to remove
      */
 
-    // function removeOrg(id) public onlyAdmin{
-    // }
+    function removeOrg(address payee) public onlyAdmin {
+        uint evaluatorId = evaluatorLookup[payee];
+
+        if (evaluatorId != 0) {
+            address payable[] storage payees = paymentLedger[evaluatorId].payees;
+
+            for (uint i = 0; i < payees.length; i++) {
+                if (payees[i] == payee) {
+                    delete payees[i];
+                    payees.length--;
+                    break;
+                }
+            }
+
+            delete evaluatorLookup[payee];
+            emit OrgRemoved(payee, evaluatorId);
+        }
+    }
 
     /**
      * @dev Donation funds are split among payees, msg.sender receives NFT clone
@@ -94,12 +139,42 @@ contract FFPaymentSplit is PaymentSplitter {
         // Check is required here to prevent reentrancy from the Kudos contract
         if (msg.sender != address(_ffKudosInterface)) {
             require(address(_ffKudosInterface) != address(0), "FFPaymentSplitter: NFT contract is not set");
-            _donationIds.increment();
+
+            uint evaluatorId = uint(uint8(msg.data[0]));
+            require(evaluatorId > 0 && evaluatorId <= MAX_EVALUATOR_ID, "Invalid evaluatorId supplied");
             uint256 newDonationId = _donationIds.current();
+            _donationIds.increment();
 
             _ffKudosInterface.clone(msg.sender, tokenId, 1);
             totalDonated += msg.value;
+            paymentLedger[evaluatorId].totalDonated += msg.value;
+
             emit DonationReceived(newDonationId, msg.sender, msg.value, msg.data);
+            _release(evaluatorId);
+        }
+    }
+
+    function release(address payable account) public {
+        uint evaluatorId = evaluatorLookup[account];
+        _release(evaluatorId);
+    }
+
+    function _release(uint evaluatorId) internal {
+        PaymentDetails storage details = paymentLedger[evaluatorId];
+        uint pendingPayment = details.totalDonated.sub(details.totalDistributed);
+
+        if (pendingPayment > 0) {
+            uint paymentShare = pendingPayment.div(details.payees.length);
+
+            for (uint256 i = 0; i < details.payees.length; i++) {
+                address payable payee = details.payees[i];
+
+                payee.transfer(paymentShare);
+                amountsWithdrew[payee] += paymentShare;
+                details.totalDistributed += paymentShare;
+
+                emit PaymentDistributed(payee, paymentShare, evaluatorId);
+            }
         }
     }
 

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -8,7 +8,9 @@ const payees = [
     "0x6526713b350083ac5812c837591d8456c5e64db6",
     "0xdc8f54f98f828da9e7ae30de176bc4108cd94599"
 ]
-const shares = [1, 1, 1];
+
+// FIXME: Use the correct evaluator ID for the payees above!
+const evaluatorIds = [1, 1, 1];
 
 module.exports = function(deployer, network) {
 
@@ -27,5 +29,5 @@ module.exports = function(deployer, network) {
     console.log(`${"-".repeat(30)}
     DEPLOYING FFPaymentSplit Contract...\n`);
 
-    deployer.deploy(FFPaymentSplit, payees, shares);
+    deployer.deploy(FFPaymentSplit, payees, evaluatorIds);
 };

--- a/test/ffpaymentsplit.js
+++ b/test/ffpaymentsplit.js
@@ -6,44 +6,86 @@ contract("FFPaymentSplit", async (accounts) => {
   let kudosInstance;
 
   beforeEach(async () => {
-    ffPaymentInstance = await FFPaymentSplit.new([accounts[4], accounts[5], accounts[6]], [1, 1 , 1]);
+    ffPaymentInstance = await FFPaymentSplit.new([accounts[4], accounts[5], accounts[6]], [1, 2, 1]);
     kudosInstance = await FFKudos.new("TestFugue", "TF");
     await kudosInstance.mint(kudosInstance.address, 0, 1337, "foo");
     await kudosInstance.setCloneFeePercentage(0);
+  });
+
+  it("should set NFT details correctly", async () => {
     await ffPaymentInstance.setNFTDetails(kudosInstance.address, 1);
+
+    const tokenId = await ffPaymentInstance.tokenId.call();
+    const tokenAddress = await ffPaymentInstance.tokenAddress.call();
+
+    assert.equal(tokenId, 1);
+    assert.equal(tokenAddress, kudosInstance.address);
   });
 
-  it("should be able to receive ether", async () => {
+  it("should distribute funds to the correct organizations with the evaluatorId supplied", async () => {
+    await ffPaymentInstance.setNFTDetails(kudosInstance.address, 1);
+
     let [,from] = accounts;
-    let value = web3.utils.toWei("3", "ether");
-
-    await ffPaymentInstance.sendTransaction({ from, value });
-
-    let balance = await web3.eth.getBalance(ffPaymentInstance.address);
-    assert.equal("3", web3.utils.fromWei(balance));
-  });
-
-  it("should distribute funds according to the shares owned", async () => {
-    let [,from] = accounts;
-    let value = web3.utils.toWei("3", "ether");
-    let data = web3.utils.toHex(2);
-
-    await ffPaymentInstance.sendTransaction({ from, value, data });
+    let value = web3.utils.toWei("4", "ether");
+    let data = web3.utils.toHex(1);
 
     let starting4 = await web3.eth.getBalance(accounts[4]);
-    await ffPaymentInstance.release(accounts[4]);
+    let starting5 = await web3.eth.getBalance(accounts[5]);
+    let starting6 = await web3.eth.getBalance(accounts[6]);
+    await ffPaymentInstance.sendTransaction({ from, value, data });
+
+    let balance4 = await web3.eth.getBalance(accounts[4]);
+    assert.equal("2", web3.utils.fromWei((balance4 - starting4).toString()));
+
+    let balance5 = await web3.eth.getBalance(accounts[5]);
+    assert.equal("0", web3.utils.fromWei((balance5 - starting5).toString()));
+
+    let balance6 = await web3.eth.getBalance(accounts[6]);
+    assert.equal("2", web3.utils.fromWei((balance6 - starting6).toString()));
+  });
+
+  it("should no longer distribute funds to organizations that have been removed", async () => {
+    await ffPaymentInstance.setNFTDetails(kudosInstance.address, 1);
+
+    await ffPaymentInstance.removeOrg(accounts[6]);
+
+    let [,,from] = accounts;
+    let value = web3.utils.toWei("3", "ether");
+    let data = web3.utils.toHex(1);
+
+    let starting4 = await web3.eth.getBalance(accounts[4]);
+    let starting6 = await web3.eth.getBalance(accounts[6]);
+    await ffPaymentInstance.sendTransaction({ from, value, data });
+
+    let balance4 = await web3.eth.getBalance(accounts[4]);
+    assert.equal("3", web3.utils.fromWei((balance4 - starting4).toString()));
+
+    let balance6 = await web3.eth.getBalance(accounts[6]);
+    assert.equal("0", web3.utils.fromWei((balance6 - starting6).toString()));
+  });
+
+  it("should distribute funds to an organization that have been added after a recent removal of another org", async () => {
+    await ffPaymentInstance.setNFTDetails(kudosInstance.address, 1);
+
+    await ffPaymentInstance.removeOrg(accounts[6]);
+    await ffPaymentInstance.addOrg(accounts[7], 1);
+
+    let [,,from] = accounts;
+    let value = web3.utils.toWei("2", "ether");
+    let data = web3.utils.toHex(1);
+
+    let starting4 = await web3.eth.getBalance(accounts[4]);
+    let starting6 = await web3.eth.getBalance(accounts[6]);
+    let starting7 = await web3.eth.getBalance(accounts[7]);
+    await ffPaymentInstance.sendTransaction({ from, value, data });
+
     let balance4 = await web3.eth.getBalance(accounts[4]);
     assert.equal("1", web3.utils.fromWei((balance4 - starting4).toString()));
 
-    let starting5 = await web3.eth.getBalance(accounts[5]);
-    await ffPaymentInstance.release(accounts[5]);
-    let balance5 = await web3.eth.getBalance(accounts[5]);
-    assert.equal("1", web3.utils.fromWei((balance5 - starting5).toString()));
-
-    let starting6 = await web3.eth.getBalance(accounts[6]);
-    await ffPaymentInstance.release(accounts[6]);
     let balance6 = await web3.eth.getBalance(accounts[6]);
-    assert.equal("1", web3.utils.fromWei((balance6 - starting6).toString()));
+    assert.equal("0", web3.utils.fromWei((balance6 - starting6).toString()));
 
+    let balance7 = await web3.eth.getBalance(accounts[7]);
+    assert.equal("1", web3.utils.fromWei((balance7 - starting7).toString()));
   });
 });


### PR DESCRIPTION
Fixes #5.

I've entirely removed inheriting from `PaymentSplitter` since the mechanism I use in this PR does not use any of its internal logic to distribute funds.

# Points to note
1. The 2nd argument to FFPaymentSplit has changed. It now accepts an array of evaluator IDs corresponding to the payee organizations. I've left a FIXME comment there to indicate that you must change it before deploying the contract to mainnet.

2. When sending funds to the contract, the recommended way of specifying the evaluator ID for `msg.data` is `web3.toHex(evaluatorId)`. Sending a string would still work, but I am not familiar with the consequences of doing so.